### PR TITLE
feat: hide Gemini key behind a free Cloudflare Worker proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,10 @@
-# Copy this file to .env.local and paste your free Gemini API key.
+# LOCAL DEV: paste your free Gemini API key here (copy this file to .env.local).
 # Get a key at: https://aistudio.google.com/apikey
-# Note: with GitHub Pages (static hosting) this key ships in the built JS bundle,
-# so treat it as disposable and rotate it if abused.
+# Safe locally — .env.local is gitignored and localhost isn't public.
 REACT_APP_GEMINI_API_KEY=your-key-here
+
+# DEPLOYED SITE: instead of a key, point the app at your Cloudflare Worker proxy
+# so the key stays server-side and never ships in the public bundle.
+# See proxy/README.md. On GitHub Pages this is set as a repo Variable, not here.
+# If this is set, it takes precedence over REACT_APP_GEMINI_API_KEY.
+# REACT_APP_GEMINI_PROXY_URL=https://buddy-gemini.your-subdomain.workers.dev

--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ REACT_APP_GEMINI_API_KEY=your-key-here
 # so the key stays server-side and never ships in the public bundle.
 # See proxy/README.md. On GitHub Pages this is set as a repo Variable, not here.
 # If this is set, it takes precedence over REACT_APP_GEMINI_API_KEY.
-# REACT_APP_GEMINI_PROXY_URL=https://buddy-gemini.your-subdomain.workers.dev
+# REACT_APP_GEMINI_PROXY_URL=https://buddy-gemini.dbdb129.workers.dev

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build (CRA) with staging base
         env:
           PUBLIC_URL: "/Buddy/stg/"
-          REACT_APP_GEMINI_API_KEY: ${{ secrets.REACT_APP_GEMINI_API_KEY }}
+          REACT_APP_GEMINI_PROXY_URL: ${{ vars.REACT_APP_GEMINI_PROXY_URL }}
         run: |
           npm run build
           cp build/index.html build/404.html

--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -32,7 +32,7 @@ jobs:
         working-directory: src
         env:
           PUBLIC_URL: "/Buddy/"
-          REACT_APP_GEMINI_API_KEY: ${{ secrets.REACT_APP_GEMINI_API_KEY }}
+          REACT_APP_GEMINI_PROXY_URL: ${{ vars.REACT_APP_GEMINI_PROXY_URL }}
         run: |
           npm run build
           cp build/index.html build/404.html

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,53 @@
+# Buddy Gemini proxy (Cloudflare Worker)
+
+A tiny Worker that keeps the Gemini API key **server-side**. The app calls this
+Worker instead of Google directly, so the key never ships in the public bundle.
+
+## One-time setup
+
+You need a free [Cloudflare account](https://dash.cloudflare.com/sign-up).
+
+From this `proxy/` folder:
+
+```bash
+cd proxy
+
+# 1. Log in to Cloudflare (opens a browser)
+npx wrangler login
+
+# 2. Store your Gemini key as a secret (paste the key when prompted)
+npx wrangler secret put GEMINI_API_KEY
+
+# 3. Deploy the Worker
+npx wrangler deploy
+```
+
+Step 3 prints your Worker URL, e.g.:
+
+```
+https://buddy-gemini.<your-subdomain>.workers.dev
+```
+
+Copy that URL — it's the proxy URL the app uses.
+
+## Point the app at the proxy
+
+- **Deployed site (GitHub Pages):** add a repository **Variable** (not a secret)
+  named `REACT_APP_GEMINI_PROXY_URL` set to the Worker URL
+  (GitHub → repo Settings → Secrets and variables → Actions → Variables tab).
+  The deploy workflows pass it into the build. No Gemini key needed in GitHub.
+
+- **Local dev:** leave `REACT_APP_GEMINI_PROXY_URL` unset and keep using your
+  `.env.local` key directly. (Optional: set it in `.env.local` to test the proxy
+  path locally.)
+
+## Updating later
+
+- Change the key: `npx wrangler secret put GEMINI_API_KEY` (re-deploy not needed).
+- Change code/allowed origins: edit `worker.js`, then `npx wrangler deploy`.
+
+## Notes
+
+- `worker.js` only forwards `POST /v1beta/models/...` calls and restricts CORS to
+  your site + localhost — it is not an open proxy for arbitrary requests.
+- Free tier is 100k requests/day, far more than this app needs.

--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -1,0 +1,75 @@
+// Buddy Gemini proxy — a tiny Cloudflare Worker that holds the Gemini API key
+// as a server-side secret and forwards requests to Google. The browser calls
+// this Worker instead of Google, so the key never ships in the public bundle.
+//
+// Deploy: see proxy/README.md
+
+const GEMINI_ORIGIN = "https://generativelanguage.googleapis.com";
+
+// Origins allowed to call this proxy (your site + local dev).
+const ALLOWED_ORIGINS = [
+  "http://localhost:3000",
+  "https://danielbenedik.github.io",
+];
+
+function corsHeaders(origin) {
+  const allowed = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[1];
+  return {
+    "Access-Control-Allow-Origin": allowed,
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers":
+      "Content-Type, x-goog-api-key, x-goog-api-client",
+    "Access-Control-Max-Age": "86400",
+    Vary: "Origin",
+  };
+}
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get("Origin") || "";
+    const cors = corsHeaders(origin);
+
+    // CORS preflight
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: cors });
+    }
+
+    if (request.method !== "POST") {
+      return new Response("Method not allowed", { status: 405, headers: cors });
+    }
+
+    const url = new URL(request.url);
+
+    // Only allow Gemini model calls (generateContent / streamGenerateContent).
+    if (!url.pathname.startsWith("/v1beta/models/")) {
+      return new Response("Forbidden", { status: 403, headers: cors });
+    }
+
+    if (!env.GEMINI_API_KEY) {
+      return new Response("Proxy missing GEMINI_API_KEY secret", {
+        status: 500,
+        headers: cors,
+      });
+    }
+
+    const target = GEMINI_ORIGIN + url.pathname + url.search;
+    const body = await request.text();
+
+    const upstream = await fetch(target, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-goog-api-key": env.GEMINI_API_KEY,
+      },
+      body,
+    });
+
+    // Stream the upstream response (SSE for summaries) straight back.
+    const headers = new Headers(cors);
+    headers.set(
+      "Content-Type",
+      upstream.headers.get("Content-Type") || "application/json",
+    );
+    return new Response(upstream.body, { status: upstream.status, headers });
+  },
+};

--- a/proxy/wrangler.jsonc
+++ b/proxy/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "buddy-gemini",
+  "main": "worker.js",
+  "compatibility_date": "2024-11-01"
+}

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -20,8 +20,18 @@ import type {
 } from "../types/catalog";
 
 const apiKey = process.env.REACT_APP_GEMINI_API_KEY;
+const proxyUrl = process.env.REACT_APP_GEMINI_PROXY_URL;
 
-const ai = new GoogleGenAI({ apiKey: apiKey ?? "" });
+// When a proxy URL is set (the deployed site), route Gemini calls through it
+// so the real key stays server-side. With no proxy (local dev) we call Gemini
+// directly using the key from .env.local.
+const ai = new GoogleGenAI(
+  proxyUrl
+    ? { apiKey: "proxy", httpOptions: { baseUrl: proxyUrl } }
+    : { apiKey: apiKey ?? "" },
+);
+
+const isConfigured = Boolean(proxyUrl || apiKey);
 
 const entrySchema = {
   type: Type.OBJECT,
@@ -86,12 +96,14 @@ function toBook(entry: RawEntry): Book {
 }
 
 export function hasApiKey(): boolean {
-  return Boolean(apiKey);
+  return isConfigured;
 }
 
 export async function getCatalog(media: MediaType): Promise<Catalog> {
-  if (!apiKey) {
-    throw new Error("Missing REACT_APP_GEMINI_API_KEY");
+  if (!isConfigured) {
+    throw new Error(
+      "Missing REACT_APP_GEMINI_API_KEY or REACT_APP_GEMINI_PROXY_URL",
+    );
   }
 
   const response = await ai.models.generateContent({
@@ -141,8 +153,10 @@ export async function* generateSummaryStream(
   book: Book,
   minutes: ReadingTime,
 ): AsyncGenerator<string> {
-  if (!apiKey) {
-    throw new Error("Missing REACT_APP_GEMINI_API_KEY");
+  if (!isConfigured) {
+    throw new Error(
+      "Missing REACT_APP_GEMINI_API_KEY or REACT_APP_GEMINI_PROXY_URL",
+    );
   }
 
   const stream = await ai.models.generateContentStream({


### PR DESCRIPTION
## Why

With GitHub Pages (static hosting) the API key gets baked into the public JS bundle, so Google detects it and auto-deletes it (happened twice). The fix: the key must live server-side. This adds a tiny free Cloudflare Worker proxy; the browser calls the Worker, the Worker holds the key and forwards to Gemini.

## Flow

```
app (no key) ──> Cloudflare Worker (key as secret) ──> Gemini ──stream──> back
```

## Changes

- `proxy/worker.js` — Worker holding `GEMINI_API_KEY` as a secret; forwards `POST /v1beta/models/...` to Gemini, streams SSE straight back, restricts CORS to the site + localhost (not an open proxy).
- `proxy/wrangler.jsonc`, `proxy/README.md` — config + one-time setup steps.
- `src/services/gemini.ts` — if `REACT_APP_GEMINI_PROXY_URL` is set, the SDK uses it as `baseUrl` with a dummy key (deployed site); otherwise direct with `REACT_APP_GEMINI_API_KEY` (local dev). No other app changes; streaming preserved.
- Deploy workflows pass `REACT_APP_GEMINI_PROXY_URL` (a repo **Variable**, not a secret) — no key ever enters the build.

## Setup (one-time, by repo owner)

1. `cd proxy && npx wrangler login && npx wrangler secret put GEMINI_API_KEY && npx wrangler deploy`
2. Add repo Variable `REACT_APP_GEMINI_PROXY_URL` = the printed Worker URL.
3. Delete the old `REACT_APP_GEMINI_API_KEY` Actions secret (no longer used).

## Verification

`tsc --noEmit`, ESLint, and the test pass. Worker validated with `wrangler deploy --dry-run`. End-to-end proxy run requires a live key + deployed Worker (owner step above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)