### PR TITLE
fix(proxy): allow User-Agent in Worker CORS preflight

### DIFF
--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -12,13 +12,19 @@ const ALLOWED_ORIGINS = [
   "https://danielbenedik.github.io",
 ];
 
-function corsHeaders(origin) {
+function corsHeaders(origin, request) {
   const allowed = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[1];
+  // Reflect whatever headers the browser asks to send. WebKit (Safari/iOS)
+  // includes User-Agent in the CORS preflight — a fixed list misses it and the
+  // request is blocked. Echoing the requested headers allows it cleanly.
+  const requested =
+    request && request.headers.get("Access-Control-Request-Headers");
   return {
     "Access-Control-Allow-Origin": allowed,
     "Access-Control-Allow-Methods": "POST, OPTIONS",
     "Access-Control-Allow-Headers":
-      "Content-Type, x-goog-api-key, x-goog-api-client",
+      requested ||
+      "Content-Type, x-goog-api-key, x-goog-api-client, User-Agent",
     "Access-Control-Max-Age": "86400",
     Vary: "Origin",
   };
@@ -27,7 +33,7 @@ function corsHeaders(origin) {
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin") || "";
-    const cors = corsHeaders(origin);
+    const cors = corsHeaders(origin, request);
 
     // CORS preflight
     if (request.method === "OPTIONS") {


### PR DESCRIPTION
## The bug

The catalog/story requests failed on **all WebKit browsers** (iPad Safari, iPad Chrome, Mac Safari) with `Load failed`, while working on Chrome/Blink.

Root cause, from Safari's console:
> Request header field **User-Agent** is not allowed by Access-Control-Allow-Headers.

The `@google/genai` SDK sets a custom `User-Agent` header. Blink silently strips it (forbidden header) so it never hits the preflight; WebKit keeps it and includes it in the CORS preflight. The Worker's fixed `Access-Control-Allow-Headers` list didn't include `User-Agent`, so WebKit blocked the request.

## The fix

The Worker now **reflects the browser's `Access-Control-Request-Headers`** back in the preflight response (with a sensible fallback list that includes `User-Agent`). Whatever the SDK sends is allowed — robust against future header changes too.

## Deploy

This is a Worker change — after merge it still needs `npx wrangler deploy` from `proxy/` to take effect (the Worker isn't deployed via GitHub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)