### PR TITLE
feat: fresh daily catalog + LLM book search

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
 
   return (
     <div className={styles.app}>
-      <Navbar media={media} onMediaChange={setMedia} />
+      <Navbar media={media} onMediaChange={setMedia} onSelect={handleSelect} />
 
       {loading && <div className={styles.center}>Loading your shelf…</div>}
 

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,34 +1,24 @@
 import MediaToggle from "../MediaToggle/MediaToggle";
+import Search from "../Search/Search";
 
 import styles from "./Navbar.module.scss";
 
-import type { MediaType } from "../../types/catalog";
+import type { Book, MediaType, ReadingTime } from "../../types/catalog";
 
 interface NavbarProps {
   media: MediaType;
   onMediaChange: (media: MediaType) => void;
+  onSelect: (book: Book, minutes: ReadingTime) => void;
 }
 
-function Navbar({ media, onMediaChange }: NavbarProps) {
+function Navbar({ media, onMediaChange, onSelect }: NavbarProps) {
   return (
     <header className={styles.navbar}>
       <div className={styles.left}>
         <span className={styles.logo}>BUDDY</span>
         <MediaToggle value={media} onChange={onMediaChange} />
       </div>
-      <svg
-        className={styles.search}
-        viewBox="0 0 24 24"
-        width="20"
-        height="20"
-        fill="none"
-        stroke="currentColor"
-        strokeWidth="2"
-        aria-hidden="true"
-      >
-        <circle cx="11" cy="11" r="7" />
-        <line x1="16.5" y1="16.5" x2="21" y2="21" />
-      </svg>
+      <Search onSelect={onSelect} />
     </header>
   );
 }

--- a/src/components/Search/Search.module.scss
+++ b/src/components/Search/Search.module.scss
@@ -1,0 +1,116 @@
+@use "../../styles/tokens" as t;
+
+.iconButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: t.$text-muted;
+  padding: 4px;
+}
+
+.iconButton:hover {
+  color: t.$text;
+}
+
+.search {
+  position: relative;
+}
+
+.form {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 240px;
+  max-width: 52vw;
+  background: #1f1f1f;
+  border: 0.5px solid rgba(255, 255, 255, 0.25);
+  border-radius: t.$radius-md;
+  padding: 6px 10px;
+}
+
+.input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: t.$text;
+  font-size: 14px;
+}
+
+.input::placeholder {
+  color: t.$text-dim;
+}
+
+.submit {
+  display: flex;
+  align-items: center;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: t.$text-muted;
+  padding: 0;
+}
+
+.submit:hover {
+  color: t.$text;
+}
+
+.dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 280px;
+  max-width: 70vw;
+  background: #1f1f1f;
+  border: 0.5px solid rgba(255, 255, 255, 0.12);
+  border-radius: t.$radius-md;
+  overflow: hidden;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.6);
+  z-index: 20;
+}
+
+.message {
+  padding: 12px 14px;
+  font-size: 13px;
+  color: t.$text-muted;
+}
+
+.result {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  padding: 10px 14px;
+  text-align: right;
+  border-bottom: 0.5px solid rgba(255, 255, 255, 0.06);
+}
+
+.result:last-child {
+  border-bottom: none;
+}
+
+.result:hover,
+.result:focus-visible {
+  background: t.$accent-soft;
+  outline: none;
+}
+
+.resultTitle {
+  width: 100%;
+  font-size: 14px;
+  color: t.$text;
+}
+
+.resultMeta {
+  width: 100%;
+  font-size: 11px;
+  color: t.$text-dim;
+}

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,0 +1,147 @@
+import { useEffect, useRef, useState } from "react";
+
+import { searchBooks } from "../../services/gemini";
+
+import styles from "./Search.module.scss";
+
+import type { Book, ReadingTime } from "../../types/catalog";
+
+interface SearchProps {
+  onSelect: (book: Book, minutes: ReadingTime) => void;
+}
+
+const MagnifierIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="20"
+    height="20"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden="true"
+  >
+    <circle cx="11" cy="11" r="7" />
+    <line x1="16.5" y1="16.5" x2="21" y2="21" />
+  </svg>
+);
+
+function Search({ onSelect }: SearchProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<Book[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) close();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  const close = () => {
+    setOpen(false);
+    setQuery("");
+    setResults(null);
+    setError(false);
+    setLoading(false);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const q = query.trim();
+    if (q.length < 2) return;
+    setLoading(true);
+    setError(false);
+    setResults(null);
+    try {
+      setResults(await searchBooks(q));
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const pick = (book: Book) => {
+    onSelect(book, 2);
+    close();
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={() => setOpen(true)}
+        aria-label="Search books"
+      >
+        <MagnifierIcon />
+      </button>
+    );
+  }
+
+  return (
+    <div className={styles.search} ref={containerRef}>
+      <form className={styles.form} onSubmit={submit}>
+        <input
+          ref={inputRef}
+          className={styles.input}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search a book…"
+          aria-label="Search a book"
+        />
+        <button type="submit" className={styles.submit} aria-label="Search">
+          <MagnifierIcon />
+        </button>
+      </form>
+
+      {(loading || error || results) && (
+        <div className={styles.dropdown}>
+          {loading && <div className={styles.message}>Searching…</div>}
+          {error && (
+            <div className={styles.message}>Search failed. Try again.</div>
+          )}
+          {results && results.length === 0 && (
+            <div className={styles.message}>No matches found.</div>
+          )}
+          {results?.map((book) => (
+            <button
+              key={book.id}
+              type="button"
+              className={styles.result}
+              onClick={() => pick(book)}
+              dir="rtl"
+              lang="he"
+            >
+              <span className={styles.resultTitle}>{book.titleHe}</span>
+              <span className={styles.resultMeta}>
+                {book.authorHe}
+                {book.year ? ` · ${book.year}` : ""}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default Search;

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -1,11 +1,15 @@
 import { GoogleGenAI, Type } from "@google/genai";
 
+import { getCached, setCached } from "../utils/cache";
 import { mapLimit } from "../utils/concurrency";
 import {
   BOOKS_PER_GENRE,
+  cacheKeys,
   catalogPrompt,
   GENRE_COUNT,
   MODEL_ID,
+  SEARCH_TTL,
+  searchPrompt,
   summaryPrompt,
 } from "../utils/constants";
 
@@ -106,12 +110,16 @@ export async function getCatalog(media: MediaType): Promise<Catalog> {
     );
   }
 
+  // Random seed + high temperature so each (daily) regeneration yields a
+  // genuinely different set of books rather than the same predictable list.
+  const seed = Math.random().toString(36).slice(2, 10);
   const response = await ai.models.generateContent({
     model: MODEL_ID,
-    contents: catalogPrompt(media),
+    contents: catalogPrompt(media, seed),
     config: {
       responseMimeType: "application/json",
       responseSchema: catalogSchema,
+      temperature: 1.3,
     },
   });
 
@@ -147,6 +155,42 @@ export async function getCatalog(media: MediaType): Promise<Catalog> {
       books: genre.books.map(applyCover),
     })),
   };
+}
+
+const searchSchema = {
+  type: Type.OBJECT,
+  properties: {
+    results: { type: Type.ARRAY, items: entrySchema },
+  },
+  required: ["results"],
+};
+
+export async function searchBooks(query: string): Promise<Book[]> {
+  if (!isConfigured) {
+    throw new Error(
+      "Missing REACT_APP_GEMINI_API_KEY or REACT_APP_GEMINI_PROXY_URL",
+    );
+  }
+
+  const cacheKey = cacheKeys.search(query);
+  const cached = getCached<Book[]>(cacheKey);
+  if (cached) return cached;
+
+  const response = await ai.models.generateContent({
+    model: MODEL_ID,
+    contents: searchPrompt(query),
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: searchSchema,
+    },
+  });
+
+  const raw = JSON.parse(response.text ?? '{"results":[]}') as {
+    results: RawEntry[];
+  };
+  const books = (raw.results ?? []).slice(0, 3).map(toBook);
+  setCached(cacheKey, books, SEARCH_TTL);
+  return books;
 }
 
 export async function* generateSummaryStream(

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -19,6 +19,7 @@ const DAY = 24 * HOUR;
 export const CATALOG_TTL = DAY;
 export const SUMMARY_TTL = 7 * DAY;
 export const COVER_TTL = 30 * DAY;
+export const SEARCH_TTL = 7 * DAY;
 
 export const cacheKeys = {
   catalog: (media: MediaType) => `buddy:catalog:${media}`,
@@ -26,24 +27,39 @@ export const cacheKeys = {
   summary: (bookId: string, minutes: ReadingTime) =>
     `buddy:summary:he:${minutes}:${bookId}`,
   cover: (bookId: string) => `buddy:cover:${bookId}`,
+  search: (query: string) => `buddy:search:${query.trim().toLowerCase()}`,
 };
 
-export function catalogPrompt(media: MediaType): string {
+export function catalogPrompt(media: MediaType, seed: string): string {
   const noun = media === "book" ? "books" : "movies";
   const creator = media === "book" ? "author" : "director";
   return [
     `Build a catalog of well-known ${noun} for a Netflix-style browsing app.`,
     `Return exactly ${GENRE_COUNT} genres.`,
-    `The FIRST genre must be the essential, most popular must-read ${noun} that`,
-    `everyone should read at least once — label it "Must-Read Favorites".`,
-    `The other ${GENRE_COUNT - 1} genres should be distinct, recognizable categories.`,
+    `The FIRST genre is essential, popular must-read ${noun} — label it "Must-Read Favorites".`,
+    `The other ${GENRE_COUNT - 1} genres should be distinct, recognizable categories,`,
+    `rotated and varied from the usual defaults.`,
     `Each genre must contain exactly ${BOOKS_PER_GENRE} famous, real, widely-recognized ${noun}.`,
     `Also pick one separate, very famous "hero" ${media} to feature at the top.`,
+    `Variation token: ${seed}. Produce a FRESH, genuinely different selection this`,
+    `time — do NOT default to the same predictable titles; rotate the genres and`,
+    `blend timeless classics with less-obvious but well-regarded works.`,
     `Avoid duplicates across genres.`,
     `Genre labels must be in English or Hebrew.`,
     `For each entry provide: the original title and ${creator} in English (for`,
     `lookup), the title translated to Hebrew (titleHe), the ${creator} name in`,
     `Hebrew (authorHe), and the release year.`,
+  ].join(" ");
+}
+
+export function searchPrompt(query: string): string {
+  return [
+    `A user is searching for a book with the query: "${query}".`,
+    `Return up to 3 real, well-known books that best match the query by title,`,
+    `author, series, or topic. For a series, include the most relevant entries.`,
+    `For each entry provide: the original title and author in English (for lookup),`,
+    `the title in Hebrew (titleHe), the author in Hebrew (authorHe), and the year.`,
+    `Return an empty list if nothing matches.`,
   ].join(" ");
 }
 


### PR DESCRIPTION
Two improvements, both verified live through the Cloudflare Worker proxy.

## 1. Fresh books every day
The catalog kept returning the same canonical titles because the prompt was deterministic. Now `getCatalog` passes a random **variation token** and uses **temperature 1.3**, and the prompt asks for a genuinely different, rotated selection (classics + less-obvious works). Each daily regeneration (24h cache) now brings a new mix.

Verified: a fresh generation produced different genres ("Thought-Provoking Science Fiction", "Historical Epics & Sagas", …) and selections.

## 2. LLM book search (Option A — expanding icon)
The top-bar magnifier expands into a search field. On **Enter / tap** it asks the LLM for **up to 3** matching books, shown in a floating dropdown (Hebrew title + author + year). Tapping a result opens that book's **2-minute** story modal. Results are cached per query (7 days) to save quota.

Verified: searching "הארי פוטר" returned the first 3 Harry Potter books in Hebrew; tapping one opened "הארי פוטר ואבן החכמים" with the 2-min toggle active and the Hebrew story streaming.

### Files
- `services/gemini.ts` — `searchBooks()`, random seed + temperature for catalog
- `utils/constants.ts` — `searchPrompt`, search cache key + TTL, varied catalog prompt
- `components/Search/` — new expanding search component
- `Navbar.tsx` / `App.tsx` — wire search to the existing select handler

Green on `tsc --noEmit`, ESLint, and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)