### PR TITLE
feat: activate Movies toggle (full movie experience)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -9,6 +9,7 @@ const fakeCatalog: Catalog = {
   media: "book",
   hero: {
     id: "dune-frank-herbert",
+    media: "book",
     title: "Dune",
     author: "Frank Herbert",
     titleHe: "חולית",
@@ -21,6 +22,7 @@ const fakeCatalog: Catalog = {
       books: [
         {
           id: "1984-george-orwell",
+          media: "book",
           title: "1984",
           author: "George Orwell",
           titleHe: "1984",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -26,9 +26,18 @@ function App() {
   const handleSelect = (book: Book, minutes: ReadingTime) =>
     setSelected({ book, minutes });
 
+  const handleMediaChange = (next: MediaType) => {
+    setSelected(null);
+    setMedia(next);
+  };
+
   return (
     <div className={styles.app}>
-      <Navbar media={media} onMediaChange={setMedia} onSelect={handleSelect} />
+      <Navbar
+        media={media}
+        onMediaChange={handleMediaChange}
+        onSelect={handleSelect}
+      />
 
       {loading && <div className={styles.center}>Loading your shelf…</div>}
 

--- a/src/components/MediaToggle/MediaToggle.tsx
+++ b/src/components/MediaToggle/MediaToggle.tsx
@@ -22,10 +22,9 @@ function MediaToggle({ value, onChange }: MediaToggleProps) {
       <button
         type="button"
         role="tab"
-        aria-selected={false}
-        className={styles.disabled}
-        disabled
-        title="Coming soon"
+        aria-selected={value === "movie"}
+        className={value === "movie" ? styles.active : styles.option}
+        onClick={() => onChange("movie")}
       >
         Movies
       </button>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -18,7 +18,7 @@ function Navbar({ media, onMediaChange, onSelect }: NavbarProps) {
         <span className={styles.logo}>BUDDY</span>
         <MediaToggle value={media} onChange={onMediaChange} />
       </div>
-      <Search onSelect={onSelect} />
+      <Search media={media} onSelect={onSelect} />
     </header>
   );
 }

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 
-import { searchBooks } from "../../services/gemini";
+import { searchTitles } from "../../services/gemini";
 
 import styles from "./Search.module.scss";
 
-import type { Book, ReadingTime } from "../../types/catalog";
+import type { Book, MediaType, ReadingTime } from "../../types/catalog";
 
 interface SearchProps {
+  media: MediaType;
   onSelect: (book: Book, minutes: ReadingTime) => void;
 }
 
@@ -25,7 +26,7 @@ const MagnifierIcon = () => (
   </svg>
 );
 
-function Search({ onSelect }: SearchProps) {
+function Search({ media, onSelect }: SearchProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<Book[] | null>(null);
@@ -70,7 +71,7 @@ function Search({ onSelect }: SearchProps) {
     setError(false);
     setResults(null);
     try {
-      setResults(await searchBooks(q));
+      setResults(await searchTitles(media, q));
     } catch {
       setError(true);
     } finally {

--- a/src/hooks/useStreamingSummary.ts
+++ b/src/hooks/useStreamingSummary.ts
@@ -22,7 +22,7 @@ export function useStreamingSummary(
     }
 
     let cancelled = false;
-    const key = cacheKeys.summary(book.id, minutes);
+    const key = cacheKeys.summary(book.media, book.id, minutes);
 
     const cached = getCached<string>(key);
     if (cached) {

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -88,9 +88,10 @@ function slugify(value: string): string {
     .replace(/(^-|-$)/g, "");
 }
 
-function toBook(entry: RawEntry): Book {
+function toBook(entry: RawEntry, media: MediaType): Book {
   return {
     id: slugify(`${entry.title}-${entry.author}`),
+    media,
     title: entry.title,
     author: entry.author,
     titleHe: entry.titleHe || entry.title,
@@ -128,9 +129,15 @@ export async function getCatalog(media: MediaType): Promise<Catalog> {
   const genres: Genre[] = raw.genres.slice(0, GENRE_COUNT).map((genre) => ({
     id: slugify(genre.label),
     label: genre.label,
-    books: genre.books.slice(0, BOOKS_PER_GENRE).map(toBook),
+    books: genre.books.slice(0, BOOKS_PER_GENRE).map((e) => toBook(e, media)),
   }));
-  const hero = toBook(raw.hero);
+  const hero = toBook(raw.hero, media);
+
+  // Covers come from Open Library (books only); movies use the colored title
+  // tiles, so skip cover lookups for them.
+  if (media !== "book") {
+    return { media, hero, genres };
+  }
 
   // Resolve covers with capped concurrency — firing all at once makes Open
   // Library throttle the burst and most lookups come back empty.
@@ -165,20 +172,23 @@ const searchSchema = {
   required: ["results"],
 };
 
-export async function searchBooks(query: string): Promise<Book[]> {
+export async function searchTitles(
+  media: MediaType,
+  query: string,
+): Promise<Book[]> {
   if (!isConfigured) {
     throw new Error(
       "Missing REACT_APP_GEMINI_API_KEY or REACT_APP_GEMINI_PROXY_URL",
     );
   }
 
-  const cacheKey = cacheKeys.search(query);
+  const cacheKey = cacheKeys.search(media, query);
   const cached = getCached<Book[]>(cacheKey);
   if (cached) return cached;
 
   const response = await ai.models.generateContent({
     model: MODEL_ID,
-    contents: searchPrompt(query),
+    contents: searchPrompt(media, query),
     config: {
       responseMimeType: "application/json",
       responseSchema: searchSchema,
@@ -188,7 +198,7 @@ export async function searchBooks(query: string): Promise<Book[]> {
   const raw = JSON.parse(response.text ?? '{"results":[]}') as {
     results: RawEntry[];
   };
-  const books = (raw.results ?? []).slice(0, 3).map(toBook);
+  const books = (raw.results ?? []).slice(0, 3).map((e) => toBook(e, media));
   setCached(cacheKey, books, SEARCH_TTL);
   return books;
 }

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -4,7 +4,8 @@ export type ReadingTime = 2 | 5;
 
 export interface Book {
   id: string;
-  // English title/author are kept for cover lookup and a stable slug id.
+  media: MediaType;
+  // English title/author (or director) are kept for lookup and a stable slug id.
   title: string;
   author: string;
   // Hebrew display strings shown in the UI.

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -23,11 +23,12 @@ export const SEARCH_TTL = 7 * DAY;
 
 export const cacheKeys = {
   catalog: (media: MediaType) => `buddy:catalog:${media}`,
-  // Keyed by reading time + "he" so each length/language is cached separately.
-  summary: (bookId: string, minutes: ReadingTime) =>
-    `buddy:summary:he:${minutes}:${bookId}`,
+  // Keyed by media + reading time + "he" so each variant is cached separately.
+  summary: (media: MediaType, bookId: string, minutes: ReadingTime) =>
+    `buddy:summary:${media}:he:${minutes}:${bookId}`,
   cover: (bookId: string) => `buddy:cover:${bookId}`,
-  search: (query: string) => `buddy:search:${query.trim().toLowerCase()}`,
+  search: (media: MediaType, query: string) =>
+    `buddy:search:${media}:${query.trim().toLowerCase()}`,
 };
 
 export function catalogPrompt(media: MediaType, seed: string): string {
@@ -36,7 +37,8 @@ export function catalogPrompt(media: MediaType, seed: string): string {
   return [
     `Build a catalog of well-known ${noun} for a Netflix-style browsing app.`,
     `Return exactly ${GENRE_COUNT} genres.`,
-    `The FIRST genre is essential, popular must-read ${noun} — label it "Must-Read Favorites".`,
+    `The FIRST genre is essential, popular must-${media === "book" ? "read" : "watch"} ${noun} —`,
+    `label it "${media === "book" ? "Must-Read Favorites" : "Must-Watch Favorites"}".`,
     `The other ${GENRE_COUNT - 1} genres should be distinct, recognizable categories,`,
     `rotated and varied from the usual defaults.`,
     `Each genre must contain exactly ${BOOKS_PER_GENRE} famous, real, widely-recognized ${noun}.`,
@@ -52,21 +54,27 @@ export function catalogPrompt(media: MediaType, seed: string): string {
   ].join(" ");
 }
 
-export function searchPrompt(query: string): string {
+export function searchPrompt(media: MediaType, query: string): string {
+  const noun = media === "book" ? "books" : "movies";
+  const creator = media === "book" ? "author" : "director";
   return [
-    `A user is searching for a book with the query: "${query}".`,
-    `Return up to 3 real, well-known books that best match the query by title,`,
-    `author, series, or topic. For a series, include the most relevant entries.`,
-    `For each entry provide: the original title and author in English (for lookup),`,
-    `the title in Hebrew (titleHe), the author in Hebrew (authorHe), and the year.`,
+    `A user is searching for a ${media} with the query: "${query}".`,
+    `Return up to 3 real, well-known ${noun} that best match the query by title,`,
+    `${creator}, series, or topic. For a series, include the most relevant entries.`,
+    `For each entry provide: the original title and ${creator} in English (for lookup),`,
+    `the title in Hebrew (titleHe), the ${creator} in Hebrew (authorHe), and the year.`,
     `Return an empty list if nothing matches.`,
   ].join(" ");
 }
 
 export function summaryPrompt(book: Book, minutes: ReadingTime): string {
   const words = WORDS_BY_TIME[minutes];
+  const subject =
+    book.media === "book"
+      ? `הספר "${book.title}" מאת ${book.author}`
+      : `הסרט "${book.title}" בבימוי ${book.author}`;
   return [
-    `ספר לי מחדש את הסיפור של הספר "${book.title}" מאת ${book.author}.`,
+    `ספר לי מחדש את הסיפור של ${subject}.`,
     `אל תכתוב סיכום ניתוחי או ביקורת — ספר את העלילה עצמה בקצרה בצורת סיפור כאילו אני קורא את הסיפור רק בצורתו הקצרה,`,
     `תעשה את זה זורם מההתחלה ועד הסוף, עם האירועים המרכזיים והתפניות החשובות`,
     `לפי סדר התרחשותם.`,


### PR DESCRIPTION
The Movies switch is now live — the whole experience (catalog, flip cards, search, Hebrew story retellings) works for films, not just books.

## What changed
- Every item carries a `media` field (`book` | `movie`).
- **Media-aware prompts:** movies use "director"/"movie", a **Must-Watch Favorites** first row, and Hebrew phrasing *"הסרט … בבימוי …"* for the story.
- **Covers:** Open Library is books-only, so `getCatalog` skips cover lookups for movies — films fall back to the colored Hebrew-title tiles (avoids showing wrong book covers).
- `searchBooks` → `searchTitles(media, query)`; summary + search cache keys now include media so book/movie variants don't collide.
- `MediaToggle` Movies button is active; switching media closes any open modal.

## Verified live
Toggled to Movies → catalog generated with hero **פורסט גאמפ** (director **רוברט זמקיס · 1994**), row **Must-Watch Favorites**, and real films in Hebrew (הסנדק, רשימת שינדלר, עיר האלוהים, פרזיטים…). The movie story request fired correctly through the proxy (only blocked by today's exhausted free quota — same path as books, which streams).

Green on `tsc --noEmit`, ESLint, and the test.

## Follow-up idea
Real movie posters would need a poster source (e.g. a free TMDB key). For now movies use the title tiles, which look consistent with the book fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)