### PR TITLE
feat: skeleton shimmer while the catalog loads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Hero from "./components/Hero/Hero";
 import Modal from "./components/Modal/Modal";
 import Navbar from "./components/Navbar/Navbar";
 import Row from "./components/Row/Row";
+import Skeleton from "./components/Skeleton/Skeleton";
 import { useCatalog } from "./hooks/useCatalog";
 
 import type { Book, MediaType, ReadingTime } from "./types/catalog";
@@ -39,7 +40,7 @@ function App() {
         onSelect={handleSelect}
       />
 
-      {loading && <div className={styles.center}>Loading your shelf…</div>}
+      {loading && <Skeleton />}
 
       {error && (
         <div className={styles.center}>

--- a/src/components/Skeleton/Skeleton.module.scss
+++ b/src/components/Skeleton/Skeleton.module.scss
@@ -1,0 +1,137 @@
+@use "../../styles/tokens" as t;
+
+@keyframes shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@mixin block {
+  background: linear-gradient(90deg, #1c1c1c 25%, #2b2b2b 37%, #1c1c1c 63%);
+  background-size: 200% 100%;
+  animation: shimmer 1.5s ease-in-out infinite;
+  border-radius: t.$radius-md;
+}
+
+.hero {
+  display: flex;
+  align-items: stretch;
+  gap: 28px;
+  padding: 40px 4vw;
+  margin-bottom: 12px;
+}
+
+.heroInfo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  flex: 1;
+  max-width: 540px;
+}
+
+.eyebrow {
+  @include block;
+  width: 110px;
+  height: 12px;
+  margin-bottom: 14px;
+}
+
+.title {
+  @include block;
+  width: 320px;
+  max-width: 80%;
+  height: 40px;
+  margin-bottom: 12px;
+}
+
+.meta {
+  @include block;
+  width: 180px;
+  height: 15px;
+  margin-bottom: 22px;
+}
+
+.want {
+  @include block;
+  width: 60px;
+  height: 14px;
+  margin-bottom: 12px;
+}
+
+.buttons {
+  display: flex;
+  gap: 12px;
+}
+
+.button {
+  @include block;
+  width: 150px;
+  height: 42px;
+  border-radius: t.$radius-sm;
+}
+
+.heroCover {
+  @include block;
+  flex: 0 0 auto;
+  width: 200px;
+  height: 300px;
+}
+
+.row {
+  margin: 0 0 28px;
+}
+
+.rowLabel {
+  @include block;
+  width: 180px;
+  height: 20px;
+  margin: 0 4vw 14px;
+}
+
+.track {
+  display: flex;
+  gap: 12px;
+  padding: 4px 4vw 12px;
+  overflow: hidden;
+}
+
+.item {
+  flex: 0 0 auto;
+  width: t.$card-width;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.chip {
+  @include block;
+  width: 90px;
+  height: 24px;
+  border-radius: 999px;
+  margin-bottom: 8px;
+}
+
+.card {
+  @include block;
+  width: 100%;
+  height: t.$card-height;
+}
+
+@media (max-width: 640px) {
+  .hero {
+    flex-direction: column-reverse;
+    align-items: flex-start;
+  }
+
+  .title {
+    height: 32px;
+  }
+
+  .heroCover {
+    width: 140px;
+    height: 210px;
+  }
+}

--- a/src/components/Skeleton/Skeleton.tsx
+++ b/src/components/Skeleton/Skeleton.tsx
@@ -1,0 +1,40 @@
+import styles from "./Skeleton.module.scss";
+
+const ROW_COUNT = 3;
+const CARD_COUNT = 7;
+
+function Skeleton() {
+  return (
+    <div aria-hidden="true" aria-busy="true">
+      <section className={styles.hero}>
+        <div className={styles.heroInfo}>
+          <div className={styles.eyebrow} />
+          <div className={styles.title} />
+          <div className={styles.meta} />
+          <div className={styles.want} />
+          <div className={styles.buttons}>
+            <div className={styles.button} />
+            <div className={styles.button} />
+          </div>
+        </div>
+        <div className={styles.heroCover} />
+      </section>
+
+      {Array.from({ length: ROW_COUNT }).map((_, row) => (
+        <section className={styles.row} key={row}>
+          <div className={styles.rowLabel} />
+          <div className={styles.track}>
+            {Array.from({ length: CARD_COUNT }).map((_, card) => (
+              <div className={styles.item} key={card}>
+                <div className={styles.chip} />
+                <div className={styles.card} />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export default Skeleton;


### PR DESCRIPTION
Replaces the plain "Loading your shelf…" text with a **shimmering skeleton** that mirrors the real layout — a hero placeholder plus 3 genre rows of card placeholders (with the title chips). The page feels instant, and when the catalog arrives it swaps in with no layout jump.

- New `components/Skeleton/` — pure presentational, dimensions match the Hero/Row/Card so there's no reflow.
- `App.tsx` shows `<Skeleton />` during the loading state.

Note: couldn't grab a live screenshot because today's Gemini free-tier quota is exhausted (the load errors in <1s, so the skeleton only flashes). Verified by build (`tsc`, ESLint, test all green) and shown via a preview of the exact shimmer. It'll be visible on a normal load once quota resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)