### PR TITLE
feat: genre refresh, summary regenerate, and a done-marker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ interface Selection {
 function App() {
   const [media, setMedia] = useState<MediaType>("book");
   const [selected, setSelected] = useState<Selection | null>(null);
-  const { catalog, loading, error } = useCatalog(media);
+  const { catalog, loading, error, refreshGenre } = useCatalog(media);
 
   const genreLabel = catalog?.genres.find((g) =>
     g.books.some((b) => b.id === selected?.book.id),
@@ -53,7 +53,12 @@ function App() {
         <main>
           <Hero book={catalog.hero} onSelect={handleSelect} />
           {catalog.genres.map((genre) => (
-            <Row key={genre.id} genre={genre} onSelect={handleSelect} />
+            <Row
+              key={genre.id}
+              genre={genre}
+              onSelect={handleSelect}
+              onRefresh={refreshGenre}
+            />
           ))}
         </main>
       )}

--- a/src/components/Modal/Modal.module.scss
+++ b/src/components/Modal/Modal.module.scss
@@ -139,6 +139,42 @@
   color: t.$text;
 }
 
+.refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: t.$text-muted;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.refresh:hover:not(:disabled) {
+  background: t.$accent;
+  color: t.$text;
+}
+
+.refresh:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.spinning svg {
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .body {
   padding: 20px 22px 26px;
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { createPortal } from "react-dom";
 
+import { useStreamingSummary } from "../../hooks/useStreamingSummary";
 import { READING_TIMES } from "../../utils/constants";
 import BookCover from "../BookCover/BookCover";
 import Summary from "../Summary/Summary";
@@ -17,6 +18,23 @@ interface ModalProps {
   onClose: () => void;
 }
 
+const RefreshIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+    <path d="M21 3v6h-6" />
+  </svg>
+);
+
 function Modal({
   book,
   minutes,
@@ -24,6 +42,8 @@ function Modal({
   onMinutesChange,
   onClose,
 }: ModalProps) {
+  const { text, status, error, reload } = useStreamingSummary(book, minutes);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -86,11 +106,23 @@ function Modal({
                   </button>
                 ))}
               </div>
+              <button
+                type="button"
+                className={`${styles.refresh} ${
+                  status === "streaming" ? styles.spinning : ""
+                }`}
+                onClick={reload}
+                disabled={status === "streaming"}
+                aria-label="Regenerate summary"
+                title="Regenerate"
+              >
+                <RefreshIcon />
+              </button>
             </div>
           </div>
         </div>
         <div className={styles.body}>
-          <Summary book={book} minutes={minutes} />
+          <Summary text={text} status={status} error={error} />
         </div>
       </div>
     </div>,

--- a/src/components/Row/Row.module.scss
+++ b/src/components/Row/Row.module.scss
@@ -4,12 +4,55 @@
   margin: 0 0 28px;
 }
 
-.label {
-  margin: 0 0 12px;
+.header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   padding: 0 4vw;
+  margin: 0 0 12px;
+}
+
+.label {
+  margin: 0;
   font-size: 20px;
   font-weight: 500;
   color: t.$text;
+}
+
+.refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: none;
+  cursor: pointer;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  color: t.$text-muted;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease;
+}
+
+.refresh:hover:not(:disabled) {
+  background: t.$accent;
+  color: t.$text;
+}
+
+.refresh:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.spinning svg {
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .track {

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import Card from "../Card/Card";
 
 import styles from "./Row.module.scss";
@@ -7,12 +9,56 @@ import type { Book, Genre, ReadingTime } from "../../types/catalog";
 interface RowProps {
   genre: Genre;
   onSelect: (book: Book, minutes: ReadingTime) => void;
+  onRefresh: (genreId: string) => Promise<void>;
 }
 
-function Row({ genre, onSelect }: RowProps) {
+const RefreshIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="15"
+    height="15"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M21 12a9 9 0 1 1-2.64-6.36" />
+    <path d="M21 3v6h-6" />
+  </svg>
+);
+
+function Row({ genre, onSelect, onRefresh }: RowProps) {
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await onRefresh(genre.id);
+    } catch {
+      // keep the current books on failure
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
   return (
     <section className={styles.row}>
-      <h2 className={styles.label}>{genre.label}</h2>
+      <div className={styles.header}>
+        <h2 className={styles.label}>{genre.label}</h2>
+        <button
+          type="button"
+          className={`${styles.refresh} ${refreshing ? styles.spinning : ""}`}
+          onClick={handleRefresh}
+          disabled={refreshing}
+          aria-label={`Refresh ${genre.label}`}
+          title="Refresh"
+        >
+          <RefreshIcon />
+        </button>
+      </div>
       <div className={styles.track}>
         {genre.books.map((book) => (
           <Card key={book.id} book={book} onSelect={onSelect} />

--- a/src/components/Summary/Summary.module.scss
+++ b/src/components/Summary/Summary.module.scss
@@ -24,6 +24,19 @@
   animation: blink 1s steps(2, start) infinite;
 }
 
+// "Done" marker — a small black square (outlined so it shows on the dark
+// surface) appended once the summary has fully streamed in.
+.doneMark {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 6px;
+  vertical-align: 1px;
+  background: #000;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 2px;
+}
+
 @keyframes blink {
   to {
     visibility: hidden;

--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -1,17 +1,14 @@
-import { useStreamingSummary } from "../../hooks/useStreamingSummary";
-
 import styles from "./Summary.module.scss";
 
-import type { Book, ReadingTime } from "../../types/catalog";
+import type { StreamStatus } from "../../types/summary";
 
 interface SummaryProps {
-  book: Book;
-  minutes: ReadingTime;
+  text: string;
+  status: StreamStatus;
+  error?: string;
 }
 
-function Summary({ book, minutes }: SummaryProps) {
-  const { text, status, error } = useStreamingSummary(book, minutes);
-
+function Summary({ text, status, error }: SummaryProps) {
   if (status === "error") {
     return (
       <p className={styles.error}>Couldn’t generate the story. {error ?? ""}</p>
@@ -23,6 +20,9 @@ function Summary({ book, minutes }: SummaryProps) {
       <p className={styles.text} dir="rtl" lang="he">
         {text}
         {status === "streaming" && <span className={styles.caret} />}
+        {status === "done" && text.length > 0 && (
+          <span className={styles.doneMark} aria-label="Summary complete" />
+        )}
       </p>
       {status === "streaming" && text.length === 0 && (
         <p className={styles.status}>Generating story…</p>

--- a/src/hooks/useCatalog.ts
+++ b/src/hooks/useCatalog.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-import { getCatalog } from "../services/gemini";
+import { generateGenreBooks, getCatalog } from "../services/gemini";
 import { getCached, setCached } from "../utils/cache";
 import { cacheKeys, CATALOG_TTL } from "../utils/constants";
 
@@ -12,12 +12,20 @@ interface CatalogState {
   error: string | null;
 }
 
-export function useCatalog(media: MediaType): CatalogState {
+interface UseCatalog extends CatalogState {
+  refreshGenre: (genreId: string) => Promise<void>;
+}
+
+export function useCatalog(media: MediaType): UseCatalog {
   const [state, setState] = useState<CatalogState>({
     catalog: null,
     loading: true,
     error: null,
   });
+
+  // Keep the latest catalog readable inside refreshGenre without stale closures.
+  const catalogRef = useRef<Catalog | null>(null);
+  catalogRef.current = state.catalog;
 
   useEffect(() => {
     let cancelled = false;
@@ -50,5 +58,28 @@ export function useCatalog(media: MediaType): CatalogState {
     };
   }, [media]);
 
-  return state;
+  const refreshGenre = useCallback(
+    async (genreId: string) => {
+      const catalog = catalogRef.current;
+      if (!catalog) return;
+      const genre = catalog.genres.find((g) => g.id === genreId);
+      if (!genre) return;
+
+      const avoid = genre.books.map((b) => b.title);
+      const books = await generateGenreBooks(media, genre.label, avoid);
+
+      setState((prev) => {
+        if (!prev.catalog) return prev;
+        const genres = prev.catalog.genres.map((g) =>
+          g.id === genreId ? { ...g, books } : g,
+        );
+        const next = { ...prev.catalog, genres };
+        setCached(cacheKeys.catalog(media), next, CATALOG_TTL);
+        return { catalog: next, loading: false, error: null };
+      });
+    },
+    [media],
+  );
+
+  return { ...state, refreshGenre };
 }

--- a/src/hooks/useStreamingSummary.ts
+++ b/src/hooks/useStreamingSummary.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { generateSummaryStream } from "../services/gemini";
 import { getCached, setCached } from "../utils/cache";
@@ -9,11 +9,16 @@ import type { SummaryState } from "../types/summary";
 
 const IDLE: SummaryState = { text: "", status: "idle" };
 
+interface UseSummary extends SummaryState {
+  reload: () => void;
+}
+
 export function useStreamingSummary(
   book: Book | null,
   minutes: ReadingTime,
-): SummaryState {
+): UseSummary {
   const [state, setState] = useState<SummaryState>(IDLE);
+  const [reloadIndex, setReloadIndex] = useState(0);
 
   useEffect(() => {
     if (!book) {
@@ -57,7 +62,17 @@ export function useStreamingSummary(
     return () => {
       cancelled = true;
     };
+  }, [book, minutes, reloadIndex]);
+
+  const reload = useCallback(() => {
+    if (!book) return;
+    try {
+      localStorage.removeItem(cacheKeys.summary(book.media, book.id, minutes));
+    } catch {
+      // best-effort
+    }
+    setReloadIndex((i) => i + 1);
   }, [book, minutes]);
 
-  return state;
+  return { ...state, reload };
 }

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -7,6 +7,7 @@ import {
   cacheKeys,
   catalogPrompt,
   GENRE_COUNT,
+  genrePrompt,
   MODEL_ID,
   SEARCH_TTL,
   searchPrompt,
@@ -171,6 +172,43 @@ const searchSchema = {
   },
   required: ["results"],
 };
+
+export async function generateGenreBooks(
+  media: MediaType,
+  label: string,
+  avoid: string[],
+): Promise<Book[]> {
+  if (!isConfigured) {
+    throw new Error(
+      "Missing REACT_APP_GEMINI_API_KEY or REACT_APP_GEMINI_PROXY_URL",
+    );
+  }
+
+  const response = await ai.models.generateContent({
+    model: MODEL_ID,
+    contents: genrePrompt(media, label, avoid),
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: searchSchema,
+      temperature: 1.3,
+    },
+  });
+
+  const raw = JSON.parse(response.text ?? '{"results":[]}') as {
+    results: RawEntry[];
+  };
+  const books = (raw.results ?? [])
+    .slice(0, BOOKS_PER_GENRE)
+    .map((e) => toBook(e, media));
+
+  if (media !== "book") return books;
+
+  const covers = await mapLimit(books, 6, fetchCoverUrl);
+  return books.map((book, i) => {
+    const url = covers[i];
+    return url ? { ...book, coverUrl: url } : book;
+  });
+}
 
 export async function searchTitles(
   media: MediaType,

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -67,6 +67,28 @@ export function searchPrompt(media: MediaType, query: string): string {
   ].join(" ");
 }
 
+export function genrePrompt(
+  media: MediaType,
+  label: string,
+  avoid: string[],
+): string {
+  const noun = media === "book" ? "books" : "movies";
+  const creator = media === "book" ? "author" : "director";
+  return [
+    `List exactly ${BOOKS_PER_GENRE} famous, real, widely-recognized ${noun}`,
+    `in the genre "${label}".`,
+    avoid.length
+      ? `Do NOT include any of these (already shown): ${avoid.join("; ")}.`
+      : "",
+    `Bring a fresh, different set of well-known titles.`,
+    `For each entry provide: the original title and ${creator} in English (for`,
+    `lookup), the title in Hebrew (titleHe), the ${creator} in Hebrew (authorHe),`,
+    `and the release year.`,
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
 export function summaryPrompt(book: Book, minutes: ReadingTime): string {
   const words = WORDS_BY_TIME[minutes];
   const subject =


### PR DESCRIPTION
Three improvements, all verified live in the browser.

## 1. Per-genre refresh ↻
A round refresh icon next to each row title refetches a **fresh set of 7 titles for just that genre** (others untouched). New `generateGenreBooks` service; `useCatalog` exposes `refreshGenre`, which updates state + cache. The icon spins while loading.
- Verified: refreshing "Must-Read Favorites" swapped all 7 books (Gatsby/1984/… → Don Quixote/Moby Dick/War and Peace/…) with new covers.

## 2. Regenerate summary ↻
A refresh icon in the modal header re-fetches the story. `useStreamingSummary` now exposes `reload()` (busts the cache + re-streams). The summary state is lifted into `Modal`; `Summary` is now a presentational component.

## 3. Done marker ◼
A small **black square** (with a thin light outline so it shows on the dark surface) is appended once the summary fully streams in — so a clean ending is easy to tell apart from a mid-stream cutoff. Verified: 12×12 marker renders at the end of a completed summary.

Green on `tsc --noEmit`, ESLint, and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)