### PR TITLE
feat: real album artwork for songs (iTunes, keyless)

### DIFF
--- a/src/services/covers.ts
+++ b/src/services/covers.ts
@@ -3,24 +3,58 @@ import { cacheKeys, COVER_TTL } from "../utils/constants";
 
 import type { Book } from "../types/catalog";
 
-const SEARCH_API = "https://openlibrary.org/search.json";
-const COVERS_BASE = "https://covers.openlibrary.org/b";
+const OL_SEARCH = "https://openlibrary.org/search.json";
+const OL_COVERS = "https://covers.openlibrary.org/b";
+const ITUNES_SEARCH = "https://itunes.apple.com/search";
 
-interface SearchResponse {
+// --- Books: Open Library ---
+interface OLResponse {
   docs?: Array<{ cover_i?: number; cover_edition_key?: string }>;
 }
 
-function coverFromDoc(doc?: {
+function olCover(doc?: {
   cover_i?: number;
   cover_edition_key?: string;
 }): string {
   if (doc?.cover_i) {
-    return `${COVERS_BASE}/id/${doc.cover_i}-L.jpg?default=false`;
+    return `${OL_COVERS}/id/${doc.cover_i}-L.jpg?default=false`;
   }
   if (doc?.cover_edition_key) {
-    return `${COVERS_BASE}/olid/${doc.cover_edition_key}-L.jpg?default=false`;
+    return `${OL_COVERS}/olid/${doc.cover_edition_key}-L.jpg?default=false`;
   }
   return "";
+}
+
+async function fetchBookCover(book: Book): Promise<string> {
+  const params = new URLSearchParams({
+    title: book.title,
+    author: book.author,
+    limit: "1",
+    fields: "cover_i,cover_edition_key",
+  });
+  const res = await fetch(`${OL_SEARCH}?${params.toString()}`);
+  if (!res.ok) return "";
+  const json = (await res.json()) as OLResponse;
+  return olCover(json.docs?.[0]);
+}
+
+// --- Movies & songs: iTunes Search (no key; CORS-friendly) ---
+interface ITunesResponse {
+  results?: Array<{ artworkUrl100?: string }>;
+}
+
+async function fetchSongArtwork(book: Book): Promise<string> {
+  const params = new URLSearchParams({
+    term: `${book.title} ${book.author}`,
+    entity: "song",
+    limit: "1",
+  });
+  const res = await fetch(`${ITUNES_SEARCH}?${params.toString()}`);
+  if (!res.ok) return "";
+  const json = (await res.json()) as ITunesResponse;
+  const art = json.results?.[0]?.artworkUrl100 ?? "";
+  // Upsize the thumbnail to a sharp cover.
+  return art ? art.replace("100x100", "600x600") : "";
 }
 
 export async function fetchCoverUrl(book: Book): Promise<string | null> {
@@ -29,16 +63,14 @@ export async function fetchCoverUrl(book: Book): Promise<string | null> {
   if (cached !== null) return cached || null;
 
   try {
-    const params = new URLSearchParams({
-      title: book.title,
-      author: book.author,
-      limit: "1",
-      fields: "cover_i,cover_edition_key",
-    });
-    const res = await fetch(`${SEARCH_API}?${params.toString()}`);
-    if (!res.ok) return null;
-    const json = (await res.json()) as SearchResponse;
-    const url = coverFromDoc(json.docs?.[0]);
+    let url = "";
+    if (book.media === "book") {
+      url = await fetchBookCover(book);
+    } else if (book.media === "song") {
+      url = await fetchSongArtwork(book);
+    }
+    // Movies have no reliable keyless poster source — they use the colored
+    // title tile (a wrong poster would be worse than a clean tile).
     setCached(cacheKey, url, COVER_TTL);
     return url || null;
   } catch {

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -134,12 +134,6 @@ export async function getCatalog(media: MediaType): Promise<Catalog> {
   }));
   const hero = toBook(raw.hero, media);
 
-  // Covers come from Open Library (books only); movies use the colored title
-  // tiles, so skip cover lookups for them.
-  if (media !== "book") {
-    return { media, hero, genres };
-  }
-
   // Resolve covers with capped concurrency — firing all at once makes Open
   // Library throttle the burst and most lookups come back empty.
   const allBooks = [hero, ...genres.flatMap((g) => g.books)];
@@ -200,8 +194,6 @@ export async function generateGenreBooks(
   const books = (raw.results ?? [])
     .slice(0, BOOKS_PER_GENRE)
     .map((e) => toBook(e, media));
-
-  if (media !== "book") return books;
 
   const covers = await mapLimit(books, 6, fetchCoverUrl);
   return books.map((book, i) => {


### PR DESCRIPTION
Songs now show **real album cover art**, fetched from the free, **keyless** iTunes Search API (`entity=song` → `artworkUrl100`, upsized to 600×600).

## Why no key / no proxy
A live check showed iTunes reflects the request origin in its CORS headers (`access-control-allow-origin: <your origin>`), so the browser can call it directly — no key, no Worker change. (My earlier "it'll be CORS-blocked" assumption was wrong; verified against the live API.)

## Routing (covers.ts now picks per media)
- **Books** → Open Library (unchanged)
- **Songs** → iTunes Search ✅
- **Movies** → colored title tile

### Why movies stay tiles
iTunes movie search is unreliable: `media=movie` returns 0 in this storefront region, and an unfiltered search returns the *wrong* film (searching "The Godfather" → "The Godfathers of Hardcore"). A wrong poster is worse than a clean tile, and there's no reliable **keyless** movie-poster source — real posters need TMDB/OMDb (free, but a key). Left as a follow-up.

Also removed the old "skip covers for non-book" guards in `getCatalog` / `generateGenreBooks`.

## Verified live
Songs row showed the correct covers: Hotel California (Eagles), Thriller, Nevermind (Nirvana), Slippery When Wet (Bon Jovi), Highway 61 Revisited (Dylan).

App-only change — green on `tsc`, ESLint, test. No `wrangler deploy` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)