### PR TITLE
feat: real movie posters via TMDB (through the Worker)

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -18,6 +18,9 @@ npx wrangler login
 # 2. Store your Gemini key as a secret (paste the key when prompted)
 npx wrangler secret put GEMINI_API_KEY
 
+# 2b. (optional) Store your TMDB key for movie posters (paste when prompted)
+npx wrangler secret put TMDB_API_KEY
+
 # 3. Deploy the Worker
 npx wrangler deploy
 ```

--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -1,10 +1,13 @@
-// Buddy Gemini proxy — a tiny Cloudflare Worker that holds the Gemini API key
-// as a server-side secret and forwards requests to Google. The browser calls
-// this Worker instead of Google, so the key never ships in the public bundle.
+// Buddy proxy — a tiny Cloudflare Worker that holds API keys as server-side
+// secrets so they never ship in the public bundle. It:
+//   - forwards Gemini calls (POST /v1beta/models/...) for catalog + stories
+//   - looks up movie posters via TMDB (GET /tmdb?query=...&year=...)
 //
 // Deploy: see proxy/README.md
 
 const GEMINI_ORIGIN = "https://generativelanguage.googleapis.com";
+const TMDB_SEARCH = "https://api.themoviedb.org/3/search/movie";
+const TMDB_IMAGE = "https://image.tmdb.org/t/p/w500";
 
 // Origins allowed to call this proxy (your site + local dev).
 const ALLOWED_ORIGINS = [
@@ -21,7 +24,7 @@ function corsHeaders(origin, request) {
     request && request.headers.get("Access-Control-Request-Headers");
   return {
     "Access-Control-Allow-Origin": allowed,
-    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
     "Access-Control-Allow-Headers":
       requested ||
       "Content-Type, x-goog-api-key, x-goog-api-client, User-Agent",
@@ -30,23 +33,52 @@ function corsHeaders(origin, request) {
   };
 }
 
+function jsonResponse(obj, cors) {
+  const headers = new Headers(cors);
+  headers.set("Content-Type", "application/json");
+  return new Response(JSON.stringify(obj), { status: 200, headers });
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get("Origin") || "";
     const cors = corsHeaders(origin, request);
+    const url = new URL(request.url);
 
     // CORS preflight
     if (request.method === "OPTIONS") {
       return new Response(null, { headers: cors });
     }
 
+    // Movie posters via TMDB (key stays server-side).
+    if (url.pathname === "/tmdb") {
+      const query = url.searchParams.get("query");
+      if (!query || !env.TMDB_API_KEY) {
+        return jsonResponse({ poster: null }, cors);
+      }
+      const tmdb = new URL(TMDB_SEARCH);
+      tmdb.searchParams.set("query", query);
+      const year = url.searchParams.get("year");
+      if (year) tmdb.searchParams.set("year", year);
+      tmdb.searchParams.set("api_key", env.TMDB_API_KEY);
+      try {
+        const res = await fetch(tmdb.toString());
+        const data = await res.json();
+        const path = data.results && data.results[0] && data.results[0].poster_path;
+        return jsonResponse(
+          { poster: path ? `${TMDB_IMAGE}${path}` : null },
+          cors,
+        );
+      } catch {
+        return jsonResponse({ poster: null }, cors);
+      }
+    }
+
+    // Everything below is the Gemini forward (POST only).
     if (request.method !== "POST") {
       return new Response("Method not allowed", { status: 405, headers: cors });
     }
 
-    const url = new URL(request.url);
-
-    // Only allow Gemini model calls (generateContent / streamGenerateContent).
     if (!url.pathname.startsWith("/v1beta/models/")) {
       return new Response("Forbidden", { status: 403, headers: cors });
     }

--- a/src/services/covers.ts
+++ b/src/services/covers.ts
@@ -6,6 +6,8 @@ import type { Book } from "../types/catalog";
 const OL_SEARCH = "https://openlibrary.org/search.json";
 const OL_COVERS = "https://covers.openlibrary.org/b";
 const ITUNES_SEARCH = "https://itunes.apple.com/search";
+// Movie posters go through the Worker (TMDB key stays server-side).
+const PROXY_URL = process.env.REACT_APP_GEMINI_PROXY_URL;
 
 // --- Books: Open Library ---
 interface OLResponse {
@@ -57,6 +59,21 @@ async function fetchSongArtwork(book: Book): Promise<string> {
   return art ? art.replace("100x100", "600x600") : "";
 }
 
+// --- Movies: TMDB via the Worker proxy (key stays server-side) ---
+interface TmdbResponse {
+  poster?: string | null;
+}
+
+async function fetchMoviePoster(book: Book): Promise<string> {
+  if (!PROXY_URL) return ""; // no proxy configured → fall back to the tile
+  const params = new URLSearchParams({ query: book.title });
+  if (book.year) params.set("year", String(book.year));
+  const res = await fetch(`${PROXY_URL}/tmdb?${params.toString()}`);
+  if (!res.ok) return "";
+  const json = (await res.json()) as TmdbResponse;
+  return json.poster ?? "";
+}
+
 export async function fetchCoverUrl(book: Book): Promise<string | null> {
   const cacheKey = cacheKeys.cover(book.id);
   const cached = getCached<string>(cacheKey);
@@ -68,9 +85,9 @@ export async function fetchCoverUrl(book: Book): Promise<string | null> {
       url = await fetchBookCover(book);
     } else if (book.media === "song") {
       url = await fetchSongArtwork(book);
+    } else {
+      url = await fetchMoviePoster(book);
     }
-    // Movies have no reliable keyless poster source — they use the colored
-    // title tile (a wrong poster would be worse than a clean tile).
     setCached(cacheKey, url, COVER_TTL);
     return url || null;
   } catch {


### PR DESCRIPTION
Movies now show **real posters** from TMDB. The TMDB key stays **server-side** in the existing Worker — nothing new to create, just a second secret + route.

## How it works
- **Worker** gains a `GET /tmdb?query=&year=` route that calls TMDB with its `TMDB_API_KEY` secret and returns `{ poster }` (an `image.tmdb.org` URL). CORS now allows GET.
- **covers.ts** routes movies → the Worker's `/tmdb` (falls back to the colored tile when there's no proxy or no match). Books → Open Library, songs → iTunes (unchanged).
- Verified the TMDB key returns correct posters (e.g. "The Godfather" 1972 → its real poster).

## ⚠️ Requires a one-time Worker update (same Worker, not a new one)
After merge, run from `proxy/`:
```bash
npm_config_registry=https://registry.npmjs.org npx --yes wrangler@latest secret put TMDB_API_KEY
npm_config_registry=https://registry.npmjs.org npx --yes wrangler@latest deploy
```
(The app change deploys via GitHub Pages on merge; the Worker route only goes live after `wrangler deploy`.)

App side is green on `tsc`, ESLint, and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)