### PR TITLE
feat: lazy-loaded genres + single 'story of the song'

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -61,17 +61,28 @@ function Card({ book, onSelect }: CardProps) {
               ↩
             </button>
             <span className={styles.want}>I want</span>
-            {READING_TIMES.map((minutes) => (
+            {book.media === "song" ? (
               <button
-                key={minutes}
                 type="button"
                 className={styles.option}
-                onClick={() => choose(minutes)}
+                onClick={() => choose(2)}
                 tabIndex={flipped ? 0 : -1}
               >
-                Story in {minutes} minutes
+                Story of the song
               </button>
-            ))}
+            ) : (
+              READING_TIMES.map((minutes) => (
+                <button
+                  key={minutes}
+                  type="button"
+                  className={styles.option}
+                  onClick={() => choose(minutes)}
+                  tabIndex={flipped ? 0 : -1}
+                >
+                  Story in {minutes} minutes
+                </button>
+              ))
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -22,19 +22,33 @@ function Hero({ book, onSelect }: HeroProps) {
           {book.authorHe}
           {book.year ? ` · ${book.year}` : ""}
         </p>
-        <span className={styles.want}>I want</span>
-        <div className={styles.options}>
-          {READING_TIMES.map((minutes) => (
+        {book.media === "song" ? (
+          <div className={styles.options}>
             <button
-              key={minutes}
               type="button"
               className={styles.cta}
-              onClick={() => onSelect(book, minutes)}
+              onClick={() => onSelect(book, 2)}
             >
-              Story in {minutes} minutes
+              Story of the song
             </button>
-          ))}
-        </div>
+          </div>
+        ) : (
+          <>
+            <span className={styles.want}>I want</span>
+            <div className={styles.options}>
+              {READING_TIMES.map((minutes) => (
+                <button
+                  key={minutes}
+                  type="button"
+                  className={styles.cta}
+                  onClick={() => onSelect(book, minutes)}
+                >
+                  Story in {minutes} minutes
+                </button>
+              ))}
+            </div>
+          </>
+        )}
       </div>
       <BookCover
         book={book}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -94,18 +94,22 @@ function Modal({
             </p>
             <div className={styles.tags}>
               {genreLabel && <span className={styles.genre}>{genreLabel}</span>}
-              <div className={styles.times}>
-                {READING_TIMES.map((m) => (
-                  <button
-                    key={m}
-                    type="button"
-                    className={m === minutes ? styles.timeActive : styles.time}
-                    onClick={() => onMinutesChange(m)}
-                  >
-                    {m} min
-                  </button>
-                ))}
-              </div>
+              {book.media !== "song" && (
+                <div className={styles.times}>
+                  {READING_TIMES.map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      className={
+                        m === minutes ? styles.timeActive : styles.time
+                      }
+                      onClick={() => onMinutesChange(m)}
+                    >
+                      {m} min
+                    </button>
+                  ))}
+                </div>
+              )}
               <button
                 type="button"
                 className={`${styles.refresh} ${

--- a/src/components/Row/Row.module.scss
+++ b/src/components/Row/Row.module.scss
@@ -72,3 +72,35 @@
   background: t.$surface-raised;
   border-radius: 999px;
 }
+
+.expand {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: auto;
+  margin: 0 4vw;
+  height: 84px;
+  border: 0.5px dashed rgba(255, 255, 255, 0.2);
+  border-radius: t.$radius-md;
+  background: rgba(255, 255, 255, 0.03);
+  color: t.$text-muted;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.expand:hover:not(:disabled) {
+  background: t.$accent-soft;
+  border-color: t.$accent;
+  color: t.$text;
+}
+
+.expand:disabled {
+  cursor: default;
+  opacity: 0.7;
+}

--- a/src/components/Row/Row.tsx
+++ b/src/components/Row/Row.tsx
@@ -29,18 +29,35 @@ const RefreshIcon = () => (
   </svg>
 );
 
-function Row({ genre, onSelect, onRefresh }: RowProps) {
-  const [refreshing, setRefreshing] = useState(false);
+const ChevronDownIcon = () => (
+  <svg
+    viewBox="0 0 24 24"
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M6 9l6 6 6-6" />
+  </svg>
+);
 
-  const handleRefresh = async () => {
-    if (refreshing) return;
-    setRefreshing(true);
+function Row({ genre, onSelect, onRefresh }: RowProps) {
+  const [busy, setBusy] = useState(false);
+  const expanded = genre.books.length > 0;
+
+  const fetchBooks = async () => {
+    if (busy) return;
+    setBusy(true);
     try {
       await onRefresh(genre.id);
     } catch {
-      // keep the current books on failure
+      // keep current state on failure
     } finally {
-      setRefreshing(false);
+      setBusy(false);
     }
   };
 
@@ -48,22 +65,37 @@ function Row({ genre, onSelect, onRefresh }: RowProps) {
     <section className={styles.row}>
       <div className={styles.header}>
         <h2 className={styles.label}>{genre.label}</h2>
+        {expanded && (
+          <button
+            type="button"
+            className={`${styles.refresh} ${busy ? styles.spinning : ""}`}
+            onClick={fetchBooks}
+            disabled={busy}
+            aria-label={`Refresh ${genre.label}`}
+            title="Refresh"
+          >
+            <RefreshIcon />
+          </button>
+        )}
+      </div>
+
+      {expanded ? (
+        <div className={styles.track}>
+          {genre.books.map((book) => (
+            <Card key={book.id} book={book} onSelect={onSelect} />
+          ))}
+        </div>
+      ) : (
         <button
           type="button"
-          className={`${styles.refresh} ${refreshing ? styles.spinning : ""}`}
-          onClick={handleRefresh}
-          disabled={refreshing}
-          aria-label={`Refresh ${genre.label}`}
-          title="Refresh"
+          className={styles.expand}
+          onClick={fetchBooks}
+          disabled={busy}
         >
-          <RefreshIcon />
+          <span>{busy ? "Loading…" : "Open"}</span>
+          <ChevronDownIcon />
         </button>
-      </div>
-      <div className={styles.track}>
-        {genre.books.map((book) => (
-          <Card key={book.id} book={book} onSelect={onSelect} />
-        ))}
-      </div>
+      )}
     </section>
   );
 }

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -56,19 +56,17 @@ const catalogSchema = {
   type: Type.OBJECT,
   properties: {
     hero: entrySchema,
-    genres: {
-      type: Type.ARRAY,
-      items: {
-        type: Type.OBJECT,
-        properties: {
-          label: { type: Type.STRING },
-          books: { type: Type.ARRAY, items: entrySchema },
-        },
-        required: ["label", "books"],
+    firstGenre: {
+      type: Type.OBJECT,
+      properties: {
+        label: { type: Type.STRING },
+        books: { type: Type.ARRAY, items: entrySchema },
       },
+      required: ["label", "books"],
     },
+    otherGenres: { type: Type.ARRAY, items: { type: Type.STRING } },
   },
-  required: ["hero", "genres"],
+  required: ["hero", "firstGenre", "otherGenres"],
 };
 
 interface RawEntry {
@@ -81,7 +79,8 @@ interface RawEntry {
 
 interface RawCatalog {
   hero: RawEntry;
-  genres: Array<{ label: string; books: RawEntry[] }>;
+  firstGenre: { label: string; books: RawEntry[] };
+  otherGenres: string[];
 }
 
 function slugify(value: string): string {
@@ -129,19 +128,25 @@ export async function getCatalog(media: MediaType): Promise<Catalog> {
 
   const raw = JSON.parse(response.text ?? "{}") as RawCatalog;
 
-  const genres: Genre[] = raw.genres.slice(0, GENRE_COUNT).map((genre) => ({
-    id: slugify(genre.label),
-    label: genre.label,
-    books: genre.books.slice(0, BOOKS_PER_GENRE).map((e) => toBook(e, media)),
-  }));
   const hero = toBook(raw.hero, media);
+  const firstBooks = raw.firstGenre.books
+    .slice(0, BOOKS_PER_GENRE)
+    .map((e) => toBook(e, media));
+  const firstGenre: Genre = {
+    id: slugify(raw.firstGenre.label),
+    label: raw.firstGenre.label,
+    books: firstBooks,
+  };
+  // Remaining genres are label-only; their books load on demand when expanded.
+  const lazyGenres: Genre[] = (raw.otherGenres ?? [])
+    .slice(0, GENRE_COUNT - 1)
+    .map((label) => ({ id: slugify(label), label, books: [] }));
 
-  // Resolve covers with capped concurrency — firing all at once makes Open
-  // Library throttle the burst and most lookups come back empty.
-  const allBooks = [hero, ...genres.flatMap((g) => g.books)];
-  const covers = await mapLimit(allBooks, 6, fetchCoverUrl);
+  // Only fetch covers for the hero + first genre, so the initial load is fast.
+  const withCovers = [hero, ...firstBooks];
+  const covers = await mapLimit(withCovers, 6, fetchCoverUrl);
   const coverById = new Map<string, string>();
-  allBooks.forEach((book, i) => {
+  withCovers.forEach((book, i) => {
     const url = covers[i];
     if (url) coverById.set(book.id, url);
   });
@@ -154,10 +159,10 @@ export async function getCatalog(media: MediaType): Promise<Catalog> {
   return {
     media,
     hero: applyCover(hero),
-    genres: genres.map((genre) => ({
-      ...genre,
-      books: genre.books.map(applyCover),
-    })),
+    genres: [
+      { ...firstGenre, books: firstGenre.books.map(applyCover) },
+      ...lazyGenres,
+    ],
   };
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -65,21 +65,18 @@ export function catalogPrompt(media: MediaType, seed: string): string {
   const { noun, creator, mustLabel } = MEDIA_INFO[media];
   return [
     `Build a catalog of well-known ${noun} for a Netflix-style browsing app.`,
-    `Return exactly ${GENRE_COUNT} genres.`,
-    `The FIRST genre is the essential, most popular must-experience ${noun} —`,
-    `label it "${mustLabel}".`,
-    `The other ${GENRE_COUNT - 1} genres should be distinct, recognizable categories,`,
-    `rotated and varied from the usual defaults.`,
-    `Each genre must contain exactly ${BOOKS_PER_GENRE} famous, real, widely-recognized ${noun}.`,
-    `Also pick one separate, very famous "hero" ${media} to feature at the top.`,
-    `Variation token: ${seed}. Produce a FRESH, genuinely different selection this`,
-    `time — do NOT default to the same predictable titles; rotate the genres and`,
-    `blend timeless classics with less-obvious but well-regarded works.`,
-    `Avoid duplicates across genres.`,
-    `Genre labels must be in English or Hebrew.`,
-    `For each entry provide: the original title and ${creator} in English (for`,
-    `lookup), the title translated to Hebrew (titleHe), the ${creator} name in`,
-    `Hebrew (authorHe), and the release year.`,
+    `Pick one very famous "hero" ${media} to feature at the top.`,
+    `Then build the FIRST genre — the essential, most popular must-experience`,
+    `${noun}, labeled "${mustLabel}" — and fully list exactly ${BOOKS_PER_GENRE}`,
+    `famous, real, widely-recognized ${noun} for it.`,
+    `Also propose ${GENRE_COUNT - 1} more distinct, recognizable genre labels`,
+    `(names only — do NOT list ${noun} for these).`,
+    `Variation token: ${seed}. Produce a FRESH, genuinely different selection`,
+    `each time — rotate the genres and picks; avoid the same predictable titles.`,
+    `Genre labels may be in English or Hebrew.`,
+    `For the hero and each entry in the first genre, provide: the original title`,
+    `and ${creator} in English (for lookup), the title in Hebrew (titleHe), the`,
+    `${creator} in Hebrew (authorHe), and the release year.`,
   ].join(" ");
 }
 
@@ -121,10 +118,10 @@ export function summaryPrompt(book: Book, minutes: ReadingTime): string {
 
   if (book.media === "song") {
     return [
-      `ספר לי על הסיפור והמשמעות של השיר "${book.title}" של ${book.author}.`,
+      `ספר לי את הסיפור של השיר "${book.title}" של ${book.author}.`,
       `אל תכתוב ניתוח מוזיקלי או ביקורת — הסבר על מה השיר מדבר, מה הסיפור או הרגש`,
       `שמאחוריו, ההקשר שבו נכתב, והמסר המרכזי שלו, בצורה זורמת וברורה.`,
-      `כתוב בעברית בלבד, בערך ${words} מילים (קריאה של כ-${minutes} דקות).`,
+      `כתוב בעברית בלבד, באורך סביר וקריא, לא ארוך מדי.`,
       `התחל ישר בתוכן, בלי כותרות, בלי נקודות, ובלי הקדמות.`,
     ].join(" ");
   }


### PR DESCRIPTION
## 1. Faster catalog load (lazy genres)
The initial catalog fetch now returns the **hero + only the first genre** (fully populated) plus the **labels** of the other genres. Each remaining row shows an **"Open"** button that fetches its titles on demand (reuses `refreshGenre`). Covers are fetched only for the hero + first genre — ~8 lookups instead of ~36 — so first paint is much faster.

Verified: only "Must-Read Favorites" had cards on load; "Science Fiction & Fantasy" expanded to 7 books (Dune, LOTR, Foundation…) when its "Open" button was clicked.

## 2. Songs: single "Story of the song"
Songs no longer offer a 2/5-minute choice:
- Hero and card-flip show one **"Story of the song"** button.
- The modal hides the time toggle.
- The song summary prompt drops the word-count/reading-time instruction — it just tells the story/meaning of the song at a reasonable length.

Verified: Billie Jean opened with no toggle and a story summary; Thriller album art shown.

App-only — green on `tsc`, ESLint, and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)