### PR TITLE
feat: English search results + summary follow the query language

### DIFF
--- a/src/components/BookCover/BookCover.tsx
+++ b/src/components/BookCover/BookCover.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { displayTitle, textDir, textLang } from "../../utils/display";
 import { placeholderColor } from "../../utils/placeholder";
 
 import type { Book } from "../../types/catalog";
@@ -33,10 +34,10 @@ function BookCover({
     <span
       className={placeholderClassName}
       style={{ background: placeholderColor(book.id) }}
-      dir="rtl"
-      lang="he"
+      dir={textDir(book)}
+      lang={textLang(book)}
     >
-      {book.titleHe}
+      {displayTitle(book)}
     </span>
   );
 }

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -3,6 +3,13 @@ import { createPortal } from "react-dom";
 
 import { useStreamingSummary } from "../../hooks/useStreamingSummary";
 import { READING_TIMES } from "../../utils/constants";
+import {
+  displayAuthor,
+  displayTitle,
+  isEnglish,
+  textDir,
+  textLang,
+} from "../../utils/display";
 import BookCover from "../BookCover/BookCover";
 import Summary from "../Summary/Summary";
 
@@ -85,11 +92,19 @@ function Modal({
             placeholderClassName={styles.coverPlaceholder}
           />
           <div className={styles.headerInfo}>
-            <h2 className={styles.title} dir="rtl" lang="he">
-              {book.titleHe}
+            <h2
+              className={styles.title}
+              dir={textDir(book)}
+              lang={textLang(book)}
+            >
+              {displayTitle(book)}
             </h2>
-            <p className={styles.meta} dir="rtl" lang="he">
-              {book.authorHe}
+            <p
+              className={styles.meta}
+              dir={textDir(book)}
+              lang={textLang(book)}
+            >
+              {displayAuthor(book)}
               {book.year ? ` · ${book.year}` : ""}
             </p>
             <div className={styles.tags}>
@@ -126,7 +141,12 @@ function Modal({
           </div>
         </div>
         <div className={styles.body}>
-          <Summary text={text} status={status} error={error} />
+          <Summary
+            text={text}
+            status={status}
+            error={error}
+            english={isEnglish(book)}
+          />
         </div>
       </div>
     </div>,

--- a/src/components/Search/Search.module.scss
+++ b/src/components/Search/Search.module.scss
@@ -89,7 +89,7 @@
   cursor: pointer;
   background: transparent;
   padding: 10px 14px;
-  text-align: right;
+  text-align: start;
   border-bottom: 0.5px solid rgba(255, 255, 255, 0.06);
 }
 

--- a/src/components/Search/Search.tsx
+++ b/src/components/Search/Search.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 
 import { searchTitles } from "../../services/gemini";
+import {
+  displayAuthor,
+  displayTitle,
+  textDir,
+  textLang,
+} from "../../utils/display";
 
 import styles from "./Search.module.scss";
 
@@ -131,12 +137,12 @@ function Search({ media, open, onOpenChange, onSelect }: SearchProps) {
               type="button"
               className={styles.result}
               onClick={() => pick(book)}
-              dir="rtl"
-              lang="he"
+              dir={textDir(book)}
+              lang={textLang(book)}
             >
-              <span className={styles.resultTitle}>{book.titleHe}</span>
+              <span className={styles.resultTitle}>{displayTitle(book)}</span>
               <span className={styles.resultMeta}>
-                {book.authorHe}
+                {displayAuthor(book)}
                 {book.year ? ` · ${book.year}` : ""}
               </span>
             </button>

--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -6,9 +6,10 @@ interface SummaryProps {
   text: string;
   status: StreamStatus;
   error?: string;
+  english?: boolean;
 }
 
-function Summary({ text, status, error }: SummaryProps) {
+function Summary({ text, status, error, english }: SummaryProps) {
   if (status === "error") {
     return (
       <p className={styles.error}>Couldn’t generate the story. {error ?? ""}</p>
@@ -17,7 +18,12 @@ function Summary({ text, status, error }: SummaryProps) {
 
   return (
     <div className={styles.summary}>
-      <p className={styles.text} dir="rtl" lang="he">
+      <p
+        className={styles.text}
+        dir={english ? "ltr" : "rtl"}
+        lang={english ? "en" : "he"}
+        style={{ textAlign: english ? "left" : "right" }}
+      >
         {text}
         {status === "streaming" && <span className={styles.caret} />}
         {status === "done" && text.length > 0 && (

--- a/src/hooks/useStreamingSummary.ts
+++ b/src/hooks/useStreamingSummary.ts
@@ -27,7 +27,12 @@ export function useStreamingSummary(
     }
 
     let cancelled = false;
-    const key = cacheKeys.summary(book.media, book.id, minutes);
+    const key = cacheKeys.summary(
+      book.media,
+      book.id,
+      minutes,
+      book.lang ?? "he",
+    );
 
     const cached = getCached<string>(key);
     if (cached) {
@@ -67,7 +72,9 @@ export function useStreamingSummary(
   const reload = useCallback(() => {
     if (!book) return;
     try {
-      localStorage.removeItem(cacheKeys.summary(book.media, book.id, minutes));
+      localStorage.removeItem(
+        cacheKeys.summary(book.media, book.id, minutes, book.lang ?? "he"),
+      );
     } catch {
       // best-effort
     }

--- a/src/services/gemini.ts
+++ b/src/services/gemini.ts
@@ -22,6 +22,7 @@ import type {
   Book,
   Catalog,
   Genre,
+  Lang,
   MediaType,
   ReadingTime,
 } from "../types/catalog";
@@ -235,7 +236,12 @@ export async function searchTitles(
   const raw = JSON.parse(response.text ?? '{"results":[]}') as {
     results: RawEntry[];
   };
-  const books = (raw.results ?? []).slice(0, 3).map((e) => toBook(e, media));
+  // Follow the query language: a Hebrew query stays Hebrew, anything else
+  // (English/Latin) shows results and the summary in English.
+  const lang: Lang = /[֐-׿]/.test(query) ? "he" : "en";
+  const books = (raw.results ?? [])
+    .slice(0, 3)
+    .map((e) => ({ ...toBook(e, media), lang }));
   setCached(cacheKey, books, SEARCH_TTL);
   return books;
 }

--- a/src/types/catalog.ts
+++ b/src/types/catalog.ts
@@ -2,9 +2,14 @@ export type MediaType = "book" | "movie" | "song";
 
 export type ReadingTime = 2 | 5;
 
+export type Lang = "en" | "he";
+
 export interface Book {
   id: string;
   media: MediaType;
+  // Display language. Unset = Hebrew (the default for catalog items); English
+  // search results are tagged "en" so their UI + summary stay in English.
+  lang?: Lang;
   // English title/author (or director) are kept for lookup and a stable slug id.
   title: string;
   author: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import type { Book, MediaType, ReadingTime } from "../types/catalog";
+import type { Book, Lang, MediaType, ReadingTime } from "../types/catalog";
 
 export const MODEL_ID = "gemini-2.5-flash";
 
@@ -45,8 +45,12 @@ export const FUNFACT_TTL = DAY;
 export const cacheKeys = {
   catalog: (media: MediaType) => `buddy:catalog:${media}`,
   // Keyed by media + reading time + "he" so each variant is cached separately.
-  summary: (media: MediaType, bookId: string, minutes: ReadingTime) =>
-    `buddy:summary:${media}:he:${minutes}:${bookId}`,
+  summary: (
+    media: MediaType,
+    bookId: string,
+    minutes: ReadingTime,
+    lang: Lang,
+  ) => `buddy:summary:${media}:${lang}:${minutes}:${bookId}`,
   cover: (bookId: string) => `buddy:cover:${bookId}`,
   search: (media: MediaType, query: string) =>
     `buddy:search:${media}:${query.trim().toLowerCase()}`,
@@ -115,14 +119,40 @@ export function genrePrompt(
 
 export function summaryPrompt(book: Book, minutes: ReadingTime): string {
   const words = WORDS_BY_TIME[minutes];
+  const english = book.lang === "en";
 
   if (book.media === "song") {
+    if (english) {
+      return [
+        `Tell me the story of the song "${book.title}" by ${book.author}.`,
+        `Don't write a musical analysis or review — explain what the song is`,
+        `about, the story or emotion behind it, the context it was written in,`,
+        `and its central message, in flowing, clear prose.`,
+        `Write in English only, a reasonable readable length, not too long.`,
+        `Start straight with the content — no headings, no bullet points, no preamble.`,
+      ].join(" ");
+    }
     return [
       `ספר לי את הסיפור של השיר "${book.title}" של ${book.author}.`,
       `אל תכתוב ניתוח מוזיקלי או ביקורת — הסבר על מה השיר מדבר, מה הסיפור או הרגש`,
       `שמאחוריו, ההקשר שבו נכתב, והמסר המרכזי שלו, בצורה זורמת וברורה.`,
       `כתוב בעברית בלבד, באורך סביר וקריא, לא ארוך מדי.`,
       `התחל ישר בתוכן, בלי כותרות, בלי נקודות, ובלי הקדמות.`,
+    ].join(" ");
+  }
+
+  if (english) {
+    const subject =
+      book.media === "book"
+        ? `the book "${book.title}" by ${book.author}`
+        : `the movie "${book.title}" directed by ${book.author}`;
+    return [
+      `Retell the story of ${subject}.`,
+      `Don't write an analytical summary or review — tell the plot itself`,
+      `concisely, as a flowing story from beginning to end, with the main`,
+      `events and key turning points in the order they happen.`,
+      `Write in English only, about ${words} words (about a ${minutes}-minute read).`,
+      `Start straight with the story — no headings, no bullet points, no preamble.`,
     ].join(" ");
   }
 

--- a/src/utils/display.ts
+++ b/src/utils/display.ts
@@ -1,0 +1,15 @@
+import type { Book } from "../types/catalog";
+
+// Catalog items have no lang (default Hebrew); English search results are "en".
+export const isEnglish = (book: Book): boolean => book.lang === "en";
+
+export const displayTitle = (book: Book): string =>
+  isEnglish(book) ? book.title : book.titleHe;
+
+export const displayAuthor = (book: Book): string =>
+  isEnglish(book) ? book.author : book.authorHe;
+
+export const textDir = (book: Book): "ltr" | "rtl" =>
+  isEnglish(book) ? "ltr" : "rtl";
+
+export const textLang = (book: Book): string => (isEnglish(book) ? "en" : "he");


### PR DESCRIPTION
When the search query is in **English** (no Hebrew characters), the results **and** the opened story now display in English. Hebrew queries stay Hebrew. The rest of the app (catalog rows, hero) stays Hebrew as before.

## How
- `Book` gains an optional `lang` (`"en" | "he"`). Catalog items default to Hebrew; `searchTitles` detects the query language (Hebrew-char regex) and tags results `"en"` or `"he"`.
- New `utils/display.ts` helpers (`displayTitle` / `displayAuthor` / `textDir` / `textLang`) used by Search, Modal, and BookCover to render the correct language + direction (LTR for English, RTL for Hebrew).
- `summaryPrompt` has English variants (book / movie / song). The summary cache key now includes `lang` so EN and HE summaries don't collide. `Summary` renders LTR for English.

## Verified live
Searching "lord of the rings" returned **English, LTR** results (Fellowship / Two Towers / Return of the King — Tolkien), and the modal opened with an **English LTR title**. The summary text couldn't be captured live because Gemini was returning transient `503`s (model overloaded) at the time, but it's wired off the same `lang` flag as the verified English results/title.

App-only — green on `tsc`, ESLint, and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)